### PR TITLE
Fixing Issue #99 : need to block request when loginUser is provided in the credential creation post body for a system created with a static effective user. 

### DIFF
--- a/release/run_integration_tests.sh
+++ b/release/run_integration_tests.sh
@@ -43,7 +43,7 @@ cd "$PRG_RELPATH"/. || exit
 export PRG_PATH=$(pwd)
 
 cd ../tapis-systemslib
-mvn verify -DskipIntegrationTests=false -Dp6spy.config.modulelist=
+mvn verify -DskipIntegrationTests=false #-Dp6spy.config.modulelist=
 RET_CODE=$?
 cd $RUN_DIR
 exit $RET_CODE

--- a/release/run_integration_tests.sh
+++ b/release/run_integration_tests.sh
@@ -43,7 +43,7 @@ cd "$PRG_RELPATH"/. || exit
 export PRG_PATH=$(pwd)
 
 cd ../tapis-systemslib
-mvn verify -DskipIntegrationTests=false #-Dp6spy.config.modulelist=
+mvn verify -DskipIntegrationTests=false -Dp6spy.config.modulelist=
 RET_CODE=$?
 cd $RUN_DIR
 exit $RET_CODE

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/gen/jooq/tables/SystemsCredInfo.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/gen/jooq/tables/SystemsCredInfo.java
@@ -92,7 +92,7 @@ public class SystemsCredInfo extends TableImpl<SystemsCredInfoRecord> {
     /**
      * The column <code>tapis_sys.systems_cred_info.host_login_user</code>.
      */
-    public final TableField<SystemsCredInfoRecord, String> HOST_LOGIN_USER = createField(DSL.name("host_login_user"), SQLDataType.CLOB.nullable(false), this, "");
+    public final TableField<SystemsCredInfoRecord, String> HOST_LOGIN_USER = createField(DSL.name("host_login_user"), SQLDataType.CLOB.nullable(false).defaultValue(DSL.field("''::text", SQLDataType.CLOB)), this, "");
 
     /**
      * The column <code>tapis_sys.systems_cred_info.is_static</code>.

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
@@ -1,61 +1,87 @@
 package edu.utexas.tacc.tapis.systems.service;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.*;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.BadRequestException;
-import com.google.gson.JsonObject;
-import com.opencsv.CSVReader;
-import okhttp3.*;
+
 import org.apache.commons.lang3.EnumUtils;
-import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.S3Client;
+
+import com.google.gson.JsonObject;
+import com.opencsv.CSVReader;
 
 import edu.utexas.tacc.tapis.client.shared.exceptions.TapisClientException;
 import edu.utexas.tacc.tapis.security.client.gen.model.SkSecret;
-import edu.utexas.tacc.tapis.security.client.model.*;
 import edu.utexas.tacc.tapis.security.client.gen.model.SkSecretVersionMetadata;
-import edu.utexas.tacc.tapis.shared.exceptions.TapisSecurityException;
-import edu.utexas.tacc.tapis.shared.exceptions.runtime.TapisRuntimeException;
+import edu.utexas.tacc.tapis.security.client.model.KeyType;
+import edu.utexas.tacc.tapis.security.client.model.SKSecretMetaParms;
+import edu.utexas.tacc.tapis.security.client.model.SKSecretReadParms;
+import edu.utexas.tacc.tapis.security.client.model.SKSecretWriteParms;
+import edu.utexas.tacc.tapis.security.client.model.SecretType;
 import edu.utexas.tacc.tapis.shared.exceptions.TapisException;
+import edu.utexas.tacc.tapis.shared.exceptions.TapisSecurityException;
 import edu.utexas.tacc.tapis.shared.exceptions.recoverable.TapisSSHAuthException;
+import edu.utexas.tacc.tapis.shared.exceptions.runtime.TapisRuntimeException;
 import edu.utexas.tacc.tapis.shared.s3.S3Connection;
 import edu.utexas.tacc.tapis.shared.ssh.apache.SSHConnection;
+import edu.utexas.tacc.tapis.shared.utils.PathUtils;
 import edu.utexas.tacc.tapis.shared.utils.TapisGsonUtils;
 import edu.utexas.tacc.tapis.shared.utils.TapisUtils;
-import edu.utexas.tacc.tapis.shared.utils.PathUtils;
 import edu.utexas.tacc.tapis.sharedapi.security.ResourceRequestUser;
 import edu.utexas.tacc.tapis.systems.client.gen.model.AuthnEnum;
 import edu.utexas.tacc.tapis.systems.config.RuntimeParameters;
 import edu.utexas.tacc.tapis.systems.dao.SystemsDao;
 import edu.utexas.tacc.tapis.systems.migrate.CredInfoInitJob;
-import edu.utexas.tacc.tapis.systems.model.*;
+import edu.utexas.tacc.tapis.systems.model.CredInfoFSM;
+import static edu.utexas.tacc.tapis.systems.model.CredInfoFSM.CREDINFO_INIT_TMP_CSV_FILE;
+import edu.utexas.tacc.tapis.systems.model.Credential;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SECRETS_MASK;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_ACCESS_KEY;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_ACCESS_SECRET;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_ACCESS_TOKEN;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_PASSWORD;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_PRIVATE_KEY;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_PUBLIC_KEY;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_REFRESH_TOKEN;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_TMS_FINGERPRINT;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_TMS_PRIVATE_KEY;
+import static edu.utexas.tacc.tapis.systems.model.Credential.SK_KEY_TMS_PUBLIC_KEY;
+import static edu.utexas.tacc.tapis.systems.model.Credential.TOP_LEVEL_SECRET_NAME;
+import edu.utexas.tacc.tapis.systems.model.CredentialInfo;
 import edu.utexas.tacc.tapis.systems.model.CredentialInfo.SyncStatus;
+import edu.utexas.tacc.tapis.systems.model.TSystem;
+import static edu.utexas.tacc.tapis.systems.model.TSystem.APIUSERID_VAR;
 import edu.utexas.tacc.tapis.systems.model.TSystem.AuthnMethod;
 import edu.utexas.tacc.tapis.systems.model.TSystem.SystemOperation;
 import edu.utexas.tacc.tapis.systems.model.TSystem.SystemType;
-import edu.utexas.tacc.tapis.systems.utils.LibUtils;
-
-import static edu.utexas.tacc.tapis.systems.model.CredInfoFSM.CREDINFO_INIT_TMP_CSV_FILE;
-import static edu.utexas.tacc.tapis.systems.model.Credential.*;
-import static edu.utexas.tacc.tapis.systems.model.TSystem.*;
 import static edu.utexas.tacc.tapis.systems.service.SystemsServiceImpl.NOT_FOUND;
+import edu.utexas.tacc.tapis.systems.utils.LibUtils;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /*
    Utility class containing Tapis credential related methods needed by the
@@ -625,6 +651,27 @@ public class CredUtils
     return verifyConnection(rUser, opName, tSystem1, authnMethod, cred, hostLoginUser);
   }
 
+  /**
+   * Reject the LoginUser field for a static effective user.
+   *
+   * LoginUser field should not be provided if the system was created with a static effective user.
+   * This is because the static effective user is already a LoginUser for the system,
+   * and there is no need to map a static effective user to a login user again.
+   *
+   * @param rUser - ResourceRequestUser containing tenant, user and request info
+   * @param sys - the TSystem to check
+   * @param cred - credentials to check
+   */
+  void checkCredentialForInvalidLoginUser(ResourceRequestUser rUser, TSystem sys, Credential cred)
+  {
+    if (!sys.isDynamicEffectiveUser() && cred != null && !StringUtils.isBlank(cred.getLoginUser()))
+    {
+      String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sys.getId());
+      log.warn(msg);
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
   /*
    * Create or update a credential using SKClient.
    * Write credentials to SK and create or update the CredentialInfo in DB.
@@ -646,14 +693,9 @@ public class CredUtils
 
 
     // LoginUser field should not be provided if the system was created with a static effective user. 
-    // This is because the static effective user is already a LoginUser for the system, 
-    // and there is no need to map a static effective user to a login user again. 
-    if (isStatic && !StringUtils.isBlank(credential.getLoginUser()))
-    {
-      String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sys.getId());
-      log.warn(msg);
-      throw new IllegalArgumentException(msg);
-    }
+    // This is because the static effective user is already a LoginUser for the system,
+    // and there is no need to map a static effective user to a login user again.
+    this.checkCredentialForInvalidLoginUser(rUser, sys, credential);
 
     // For CredentialInfo record, if static then tapisUser is oboUser, if dynamic then tapisUser is targetUser
     // NOTE: targetUser is never from loginUserMapping.

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
@@ -47,6 +47,9 @@ import edu.utexas.tacc.tapis.systems.dao.SystemsDao;
 import edu.utexas.tacc.tapis.systems.migrate.CredInfoInitJob;
 import edu.utexas.tacc.tapis.systems.model.*;
 import edu.utexas.tacc.tapis.systems.model.CredentialInfo.SyncStatus;
+import edu.utexas.tacc.tapis.systems.model.TSystem.AuthnMethod;
+import edu.utexas.tacc.tapis.systems.model.TSystem.SystemOperation;
+import edu.utexas.tacc.tapis.systems.model.TSystem.SystemType;
 import edu.utexas.tacc.tapis.systems.utils.LibUtils;
 
 import static edu.utexas.tacc.tapis.systems.model.CredInfoFSM.CREDINFO_INIT_TMP_CSV_FILE;
@@ -640,6 +643,18 @@ public class CredUtils
     if (StringUtils.isBlank(hostLoginUser)) throw new IllegalArgumentException(LibUtils.getMsgAuth("SYSLIB_NULL_INPUT_HOST_LOGIN", rUser));
     String oboUser = rUser.getOboUserId();
     String loginUserMapping = credential.getLoginUser();
+
+
+    // LoginUser field should not be provided if the system was created with a static effective user. 
+    // This is because the static effective user is already a LoginUser for the system, 
+    // and there is no need to map a static effective user to a login user again. 
+    if (isStatic && !StringUtils.isBlank(credential.getLoginUser()))
+    {
+      String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sys.getId());
+      log.warn(msg);
+      throw new IllegalArgumentException(msg);
+    }
+
     // For CredentialInfo record, if static then tapisUser is oboUser, if dynamic then tapisUser is targetUser
     // NOTE: targetUser is never from loginUserMapping.
     String tapisUser = isStatic ? oboUser : credTargetUser;

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/CredUtils.java
@@ -654,7 +654,9 @@ public class CredUtils
   /**
    * Reject the LoginUser field for a static effective user.
    *
-   * LoginUser field should not be provided if the system was created with a static effective user.
+   * LoginUser field should not be provided in the *Credential* object if: 
+   *    1. a credential is being created for a system that was created with a static effective user; Or, 
+   *    2. a system with a static effective user is being created with the credential. 
    * This is because the static effective user is already a LoginUser for the system,
    * and there is no need to map a static effective user to a login user again.
    *

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
@@ -304,12 +304,14 @@ public class SystemsServiceImpl implements SystemsService
       // NOTE: If effectiveUserId is dynamic then request has already been rejected above during
       //       call to validateTSystem(). See method TSystem.checkAttrMisc().
       //       But we include isStaticEffectiveUser here anyway in case that ever changes.
-      if (isStaticEffectiveUser && !StringUtils.isBlank(cred.getLoginUser()))
-      {
-        String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sysId);
-        log.warn(msg);
-        throw new IllegalArgumentException(msg);
-      }
+      // FIXME: The following is temporarily commented off and moved to credUtils.createCredential method.
+      // 
+      // if (isStaticEffectiveUser && !StringUtils.isBlank(cred.getLoginUser()))
+      // {
+      //   String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sysId);
+      //   log.warn(msg);
+      //   throw new IllegalArgumentException(msg);
+      // }
 
       // ---------------- Verify credentials if not skipped
       if (!skipCredCheck && manageCredentials)

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
@@ -42,6 +42,10 @@ import edu.utexas.tacc.tapis.systems.config.RuntimeParameters;
 import edu.utexas.tacc.tapis.systems.dao.SystemsDao;
 import edu.utexas.tacc.tapis.systems.utils.LibUtils;
 import edu.utexas.tacc.tapis.systems.model.*;
+import edu.utexas.tacc.tapis.systems.model.TSystem.AuthnMethod;
+import edu.utexas.tacc.tapis.systems.model.TSystem.Permission;
+import edu.utexas.tacc.tapis.systems.model.TSystem.SystemOperation;
+import edu.utexas.tacc.tapis.systems.model.TSystem.SystemType;
 
 import static edu.utexas.tacc.tapis.shared.TapisConstants.SYSTEMS_SERVICE;
 import static edu.utexas.tacc.tapis.systems.model.TSystem.*;
@@ -305,14 +309,7 @@ public class SystemsServiceImpl implements SystemsService
       //       call to validateTSystem(). See method TSystem.checkAttrMisc().
       //       But we include isStaticEffectiveUser here anyway in case that ever changes.
       // ---------------------------------------------
-      // TODO: The following is temporarily commented off and moved to credUtils.createCredential method.
-      //       We should test the new change thoroughly and see if it applies to all use cases correctly.
-      // ---------------------------------------------
-      // if (isStaticEffectiveUser && !StringUtils.isBlank(cred.getLoginUser()))
-      // {
-      //   String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sysId);
-      //   log.warn(msg);
-      //   throw new IllegalArgumentException(msg);
+      credUtils.checkCredentialForInvalidLoginUser(rUser, system, cred);
 
       // ---------------- Verify credentials if not skipped
       if (!skipCredCheck && manageCredentials)

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
@@ -304,8 +304,10 @@ public class SystemsServiceImpl implements SystemsService
       // NOTE: If effectiveUserId is dynamic then request has already been rejected above during
       //       call to validateTSystem(). See method TSystem.checkAttrMisc().
       //       But we include isStaticEffectiveUser here anyway in case that ever changes.
-      // FIXME: The following is temporarily commented off and moved to credUtils.createCredential method.
-      // 
+      // ---------------------------------------------
+      // TODO: The following is temporarily commented off and moved to credUtils.createCredential method.
+      //       We should test the new change thoroughly and see if it applies to all use cases correctly.
+      // ---------------------------------------------
       // if (isStaticEffectiveUser && !StringUtils.isBlank(cred.getLoginUser()))
       // {
       //   String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sysId);

--- a/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
+++ b/tapis-systemslib/src/main/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceImpl.java
@@ -313,7 +313,6 @@ public class SystemsServiceImpl implements SystemsService
       //   String msg = LibUtils.getMsgAuth("SYSLIB_CRED_INVALID_LOGINUSER", rUser, sysId);
       //   log.warn(msg);
       //   throw new IllegalArgumentException(msg);
-      // }
 
       // ---------------- Verify credentials if not skipped
       if (!skipCredCheck && manageCredentials)

--- a/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
+++ b/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
@@ -67,7 +67,7 @@ SYSLIB_PERM_ORPHAN=SYSLIB_PERM_ORPHAN Removing permissions associated with non-e
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name, 5 = operation
 SYSLIB_CRED_SK_ERROR=SYSLIB_CRED_SK_ERROR Error operating on credentials. See underlying exception. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} Operation: {5}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name
-SYSLIB_CRED_INVALID_LOGINUSER=SYSLIB_CRED_INVALID_LOGINUSER Request must not contain loginUser because the system is now with a static effective user. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4}
+SYSLIB_CRED_INVALID_LOGINUSER=SYSLIB_CRED_INVALID_LOGINUSER Request must not contain loginUser because the system has a static effective user. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = target user name, 7 = authnMethod
 SYSLIB_CRED_NOT_SUPPORTED=SYSLIB_CRED_NOT_SUPPORTED Credential validation failed. Not supported for system type. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} HostLoginUser: {6} AuthnMethod: {7}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = targetUser, 6 = TMS url

--- a/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
+++ b/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
@@ -114,8 +114,6 @@ SYSLIB_CRED_VERIFY_ERROR=SYSLIB_CRED_VERIFY_ERROR Error during credential valida
 SYSLIB_CRED_DB_INSERT_LOGINMAP=SYSLIB_CRED_DB_INSERT_LOGINMAP Insert new loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
 # 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
 SYSLIB_CRED_DB_UPDATE_LOGINMAP=SYSLIB_CRED_DB_UPDATE_LOGINMAP Update loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
-# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
-# SYSLIB_CRED_STATIC_USER_LOGIN_MAP=SYSLIB_CRED_STATIC_USER_LOGIN_MAP A login user mapping has been specified for a system with a static effective user. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir, 9 = error
 #SYSLIB_CREATE_ROOT_ERR1=SYSLIB_CREATE_ROOT_ERR1 Unable to create SFTP client. jwtTenant: {0} jwtUser: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} rootDir: {8} Error: {9}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir

--- a/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
+++ b/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
@@ -110,10 +110,6 @@ SYSLIB_CRED_VERIFY_END=SYSLIB_CRED_VERIFY_END Credentials checked. jwtTenant: {0
 SYSLIB_CRED_VERIFY_SKIP=SYSLIB_CRED_VERIFY_SKIP Skip credential check. Not supported for system type. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} AuthnMethod: {8}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name, 5 = system type, 6 = host, 7 = hostLoginUser, 8 = authnMethod
 SYSLIB_CRED_VERIFY_ERROR=SYSLIB_CRED_VERIFY_ERROR Error during credential validation. Unexpected null. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} AuthnMethod: {8}
-# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
-SYSLIB_CRED_DB_INSERT_LOGINMAP=SYSLIB_CRED_DB_INSERT_LOGINMAP Insert new loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
-# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
-SYSLIB_CRED_DB_UPDATE_LOGINMAP=SYSLIB_CRED_DB_UPDATE_LOGINMAP Update loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir, 9 = error
 #SYSLIB_CREATE_ROOT_ERR1=SYSLIB_CREATE_ROOT_ERR1 Unable to create SFTP client. jwtTenant: {0} jwtUser: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} rootDir: {8} Error: {9}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir

--- a/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
+++ b/tapis-systemslib/src/main/resources/edu/utexas/tacc/tapis/systems/SysLibMessages.properties
@@ -67,7 +67,7 @@ SYSLIB_PERM_ORPHAN=SYSLIB_PERM_ORPHAN Removing permissions associated with non-e
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name, 5 = operation
 SYSLIB_CRED_SK_ERROR=SYSLIB_CRED_SK_ERROR Error operating on credentials. See underlying exception. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} Operation: {5}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name
-SYSLIB_CRED_INVALID_LOGINUSER=SYSLIB_CRED_INVALID_LOGINUSER Request must not contain loginUser. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4}
+SYSLIB_CRED_INVALID_LOGINUSER=SYSLIB_CRED_INVALID_LOGINUSER Request must not contain loginUser because the system is now with a static effective user. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = target user name, 7 = authnMethod
 SYSLIB_CRED_NOT_SUPPORTED=SYSLIB_CRED_NOT_SUPPORTED Credential validation failed. Not supported for system type. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} HostLoginUser: {6} AuthnMethod: {7}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = targetUser, 6 = TMS url
@@ -110,6 +110,12 @@ SYSLIB_CRED_VERIFY_END=SYSLIB_CRED_VERIFY_END Credentials checked. jwtTenant: {0
 SYSLIB_CRED_VERIFY_SKIP=SYSLIB_CRED_VERIFY_SKIP Skip credential check. Not supported for system type. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} AuthnMethod: {8}
 # 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = system name, 5 = system type, 6 = host, 7 = hostLoginUser, 8 = authnMethod
 SYSLIB_CRED_VERIFY_ERROR=SYSLIB_CRED_VERIFY_ERROR Error during credential validation. Unexpected null. jwtTenant: {0} jwtUserId: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} AuthnMethod: {8}
+# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
+SYSLIB_CRED_DB_INSERT_LOGINMAP=SYSLIB_CRED_DB_INSERT_LOGINMAP Insert new loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
+# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
+SYSLIB_CRED_DB_UPDATE_LOGINMAP=SYSLIB_CRED_DB_UPDATE_LOGINMAP Update loginUser mapping. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
+# 0 = tenant, 1 = system, 2 = tapis user, 3 = login user
+# SYSLIB_CRED_STATIC_USER_LOGIN_MAP=SYSLIB_CRED_STATIC_USER_LOGIN_MAP A login user mapping has been specified for a system with a static effective user. Tenant: {0} System: {1} TapisUser: {2} LoginUser: {3}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir, 9 = error
 #SYSLIB_CREATE_ROOT_ERR1=SYSLIB_CREATE_ROOT_ERR1 Unable to create SFTP client. jwtTenant: {0} jwtUser: {1} OboTenant: {2} OboUser: {3} System: {4} SystemType: {5} Host: {6} EffectiveUser: {7} rootDir: {8} Error: {9}
 ## 0 = jwtTenant, 1 = jwtUser, 2 = oboTenant, 3 = oboUser, 4 = sys name, 5 = sys type, 6 = host, 7 = effUser, 8 = rootDir

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -909,8 +909,6 @@ public class SystemsServiceTest
     systems = svc.getSystems(rAdminUser, searchListNull, limitNone, orderByListNull, skipZero, startAferEmpty,
                              showDeletedFalse, listTypeAll.name(), fetchShareInfoFalse, owner5); 
 
-    systems.forEach(s -> System.out.printf("TESTID=%s, ID=%s owner=%s public=%s shared=%s effectiveUser=%s%n", testID, s.getId(), s.getOwner(), s.isPublic(), s.getSharedWithUsers(), s.getEffectiveUserId()));
-
     Assert.assertNotNull(systems, "Returned list of systems should not be null");
     System.out.printf("getSystems returned %d items using listType = %s%n", systems.size(), listTypeAll);
     Assert.assertEquals(systems.size(), 2, "Wrong number of returned systems tenant for admin impersonation");

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -1264,6 +1264,7 @@ public class SystemsServiceTest
     }
     catch (Exception e)
     {
+      Assert.assertTrue(e instanceof IllegalArgumentException);
       Assert.assertTrue(e.getMessage().contains("SYSLIB_CRED_INVALID_LOGINUSER"));
       pass = true;
     }
@@ -1727,6 +1728,15 @@ public class SystemsServiceTest
     // Get as testUser3 and check cred. Since it is static should always get back cred for testUser5
     tmpSys = svc.getSystem(rFilesSvcTestUser3, sysId, AuthnMethod.PASSWORD, false, getCredsTrue, null, sharedCtxNull, resourceTenantNull, fetchShareInfoFalse);
     checkCredPasswordAndEffectiveUser(tmpSys, cred5NoLoginLinuxUser.getPassword(), testUser5, testUser5LinuxUser);
+
+    boolean passed = false;
+    try {
+        svcCred.createUserCredential(rOwner1, sysId, testUser5LinuxUser, cred5B_LoginUser, createTmsKeysFalse, skipCredCheckTrue, rawDataEmptyJson);
+    } catch (IllegalArgumentException e) {
+        String msg = e.getMessage();
+        passed = msg.contains("SYSLIB_CRED_INVALID_LOGINUSER");
+    }
+    Assert.assertTrue(passed, "Expected credential creation to be rejected");
 
     // ------------------------
     // Test 4: patch system to revert to dynamic effectiveUserId = ${apiUserId}, get cred

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -12,6 +12,7 @@ import edu.utexas.tacc.tapis.shared.utils.TapisUtils;
 import edu.utexas.tacc.tapis.sharedapi.security.AuthenticatedUser;
 import edu.utexas.tacc.tapis.sharedapi.security.ResourceRequestUser;
 import edu.utexas.tacc.tapis.systems.IntegrationUtils;
+import edu.utexas.tacc.tapis.systems.IntegrationUtils.TmsGetPubKeyRequest;
 import edu.utexas.tacc.tapis.systems.config.RuntimeParameters;
 import edu.utexas.tacc.tapis.systems.dao.SystemsDao;
 import edu.utexas.tacc.tapis.systems.dao.SystemsDaoImpl;
@@ -860,6 +861,7 @@ public class SystemsServiceTest
   @Test
   public void testGetSystemsByListType() throws Exception
   {
+    var testID = "testGetSystemsByListType_"+System.currentTimeMillis();
     var sharedIDs = new HashSet<String>();
     // Create 4 systems.
     // One owned by owner3
@@ -904,7 +906,10 @@ public class SystemsServiceTest
 
     // Test tenant admin impersonating rOwner5 - should see 2 (1 owned + 1 public)
     systems = svc.getSystems(rAdminUser, searchListNull, limitNone, orderByListNull, skipZero, startAferEmpty,
-                             showDeletedFalse, listTypeAll.name(), fetchShareInfoFalse, owner5);
+                             showDeletedFalse, listTypeAll.name(), fetchShareInfoFalse, owner5); 
+
+    systems.forEach(s -> System.out.printf("TESTID=%s, ID=%s owner=%s public=%s shared=%s effectiveUser=%s%n", testID, s.getId(), s.getOwner(), s.isPublic(), s.getSharedWithUsers(), s.getEffectiveUserId()));
+
     Assert.assertNotNull(systems, "Returned list of systems should not be null");
     System.out.printf("getSystems returned %d items using listType = %s%n", systems.size(), listTypeAll);
     Assert.assertEquals(systems.size(), 2, "Wrong number of returned systems tenant for admin impersonation");
@@ -1046,7 +1051,7 @@ public class SystemsServiceTest
   }
 
   // Check that if systems already exists we get an IllegalStateException when attempting to create
-  @Test(expectedExceptions = {IllegalStateException.class},  expectedExceptionsMessageRegExp = "^SYSLIB_SYS_EXISTS.*")
+  @Test(enabled = false, expectedExceptions = {IllegalStateException.class},  expectedExceptionsMessageRegExp = "^SYSLIB_SYS_EXISTS.*")
   public void testCreateSystemAlreadyExists() throws Exception
   {
     // Create the system
@@ -1055,6 +1060,7 @@ public class SystemsServiceTest
     Assert.assertTrue(svc.checkForSystem(rOwner1, sys0.getId()));
     // Now attempt to create again, should get IllegalStateException with msg SYSLIB_SYS_EXISTS
     svc.createSystem(rOwner1, sys0, skipCredCheckTrue, rawDataEmptyJson);
+    svcImpl.hardDeleteSystem(rAdminUser, tenantName, systems[8].getId());
   }
 
   // Check that reserved names are honored.
@@ -1245,6 +1251,30 @@ public class SystemsServiceTest
     Assert.assertTrue(pass);
     // Reset in prep for continued checking
     pass = false;
+
+    // --- test rejection of action when login user is provided for a system with a static
+    // --- effective user ID already. 
+
+    // If canExec is false then dtnSystemId may not be set
+    pass = false;
+    // A minimal system has canExec=false
+    TSystem logEffTestSys = makeMinimalSystem(sys0, null);
+    logEffTestSys.setEffectiveUserId("testuser3");
+    Credential fakeCred = new Credential(AuthnMethod.PASSWORD, "testuser99", "fakePassword", 
+        null, null, null, null, null, null, null, null, null, null);
+    logEffTestSys.setAuthnCredential(fakeCred);   
+    try { 
+        svc.createSystem(rOwner1, logEffTestSys, skipCredCheckTrue, rawDataEmptyJson); 
+    }
+    catch (Exception e)
+    {
+      Assert.assertTrue(e.getMessage().contains("SYSLIB_CRED_INVALID_LOGINUSER"));
+      pass = true;
+    }
+    Assert.assertTrue(pass);
+    // Reset in prep for continued checking
+    pass = false;
+
   }
 
   // Test restrictions on creating a system that uses HOST_EVAL in rootDir

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -295,6 +295,7 @@ public class SystemsServiceTest
   @Test
   public void testCreateSystem() throws Exception
   {
+    System.out.println("=========HELLO CREATING SYSTEM========");
     TSystem sys0 = systems[0];
     svc.createSystem(rOwner1, sys0, skipCredCheckTrue, rawDataEmptyJson);
   }
@@ -1051,7 +1052,7 @@ public class SystemsServiceTest
   }
 
   // Check that if systems already exists we get an IllegalStateException when attempting to create
-  @Test(enabled = false, expectedExceptions = {IllegalStateException.class},  expectedExceptionsMessageRegExp = "^SYSLIB_SYS_EXISTS.*")
+  @Test(expectedExceptions = {IllegalStateException.class},  expectedExceptionsMessageRegExp = "^SYSLIB_SYS_EXISTS.*")
   public void testCreateSystemAlreadyExists() throws Exception
   {
     // Create the system
@@ -1060,7 +1061,7 @@ public class SystemsServiceTest
     Assert.assertTrue(svc.checkForSystem(rOwner1, sys0.getId()));
     // Now attempt to create again, should get IllegalStateException with msg SYSLIB_SYS_EXISTS
     svc.createSystem(rOwner1, sys0, skipCredCheckTrue, rawDataEmptyJson);
-    svcImpl.hardDeleteSystem(rAdminUser, tenantName, systems[8].getId());
+    // svcImpl.hardDeleteSystem(rAdminUser, tenantName, systems[8].getId());
   }
 
   // Check that reserved names are honored.

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -1250,8 +1250,6 @@ public class SystemsServiceTest
 
     // --- test rejection of action when login user is provided for a system with a static
     // --- effective user ID already. 
-
-    // If canExec is false then dtnSystemId may not be set
     pass = false;
     // A minimal system has canExec=false
     TSystem logEffTestSys = makeMinimalSystem(sys0, null);

--- a/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
+++ b/tapis-systemslib/src/test/java/edu/utexas/tacc/tapis/systems/service/SystemsServiceTest.java
@@ -295,7 +295,6 @@ public class SystemsServiceTest
   @Test
   public void testCreateSystem() throws Exception
   {
-    System.out.println("=========HELLO CREATING SYSTEM========");
     TSystem sys0 = systems[0];
     svc.createSystem(rOwner1, sys0, skipCredCheckTrue, rawDataEmptyJson);
   }
@@ -862,7 +861,6 @@ public class SystemsServiceTest
   @Test
   public void testGetSystemsByListType() throws Exception
   {
-    var testID = "testGetSystemsByListType_"+System.currentTimeMillis();
     var sharedIDs = new HashSet<String>();
     // Create 4 systems.
     // One owned by owner3
@@ -1059,7 +1057,6 @@ public class SystemsServiceTest
     Assert.assertTrue(svc.checkForSystem(rOwner1, sys0.getId()));
     // Now attempt to create again, should get IllegalStateException with msg SYSLIB_SYS_EXISTS
     svc.createSystem(rOwner1, sys0, skipCredCheckTrue, rawDataEmptyJson);
-    // svcImpl.hardDeleteSystem(rAdminUser, tenantName, systems[8].getId());
   }
 
   // Check that reserved names are honored.


### PR DESCRIPTION
Fixing Issue #99 : need to block request when loginUser is provided in the credential creation post body for a system created with a static effective user. 

See  https://github.com/tapis-project/tapis-systems/issues/99 for more details.


Validated by:

- [x] Local Unit Test
- [x] Local Postman Scenario Test

Test Result from SystemsServiceTest

<img width="599" height="65" alt="image" src="https://github.com/user-attachments/assets/8bc87164-3671-4f53-a4a2-1463b0650d69" />

Postman API test results:

<img width="781" height="314" alt="image" src="https://github.com/user-attachments/assets/867f0501-0e1a-4fb9-8954-3f1a4a0a8b18" />
